### PR TITLE
✨ Feat: 더존 이메일 인증 + 모집 글 작성자 인증 마크

### DIFF
--- a/src/components/auth/AuthContext.tsx
+++ b/src/components/auth/AuthContext.tsx
@@ -9,6 +9,7 @@ export interface AuthContextProp {
   signin: (email: string, password: string) => Promise<void>;
   kakaoSignin: () => Promise<void>;
   updateName: (name: string) => Promise<void>;
+  verifyDouzoneEmail: (email: string, code: string) => Promise<void>;
   signout: () => Promise<void>;
   processingSignin: boolean;
   updateProfileImage: (filepath: string) => Promise<void>;
@@ -23,6 +24,7 @@ const AuthContext = createContext<AuthContextProp>({
   signin: async () => {},
   kakaoSignin: async () => {},
   updateName: async () => {},
+  verifyDouzoneEmail: async () => {},
   signout: async () => {},
   processingSignin: false,
   updateProfileImage: async () => {},

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -43,6 +43,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
               email: response.data.email || "",
               name: response.data.name || "",
               profileUrl: response.data.profileUrl || "",
+              verified: response.data.verified ?? false,
             });
           }
         }
@@ -81,6 +82,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
                     email: retryResponse.data.email || "",
                     name: retryResponse.data.name || "",
                     profileUrl: retryResponse.data.profileUrl || "",
+                    verified: retryResponse.data.verified ?? false,
                   });
                 } else {
                   await signout();
@@ -150,6 +152,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             email: email,
             name: "익명",
             profileUrl: "",
+            verified: false,
           });
           navigation.navigate("BottomTab", {
             screen: "Connect",
@@ -215,6 +218,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         email: me.data.email || "",
         name: me.data.name || "",
         profileUrl: me.data.profileUrl || "",
+        verified: me.data.verified ?? false,
       });
 
       navigation.navigate("BottomTab", { screen: "Connect" });
@@ -246,6 +250,26 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }
   }, []);
 
+  // 더존 이메일 인증 확정. 성공 시 로컬 user.verified 를 true 로 갱신한다.
+  const verifyDouzoneEmail = useCallback(async (email: string, code: string) => {
+    const accessToken = await AsyncStorage.getItem("accessToken");
+    try {
+      const response = await axiosInstance.post(
+        "/api/account/verify-douzone/confirm",
+        { email, code },
+        { headers: { Authorization: `Bearer ${accessToken}` } }
+      );
+      const updated = response.data?.data;
+      setUser((prev) =>
+        prev ? { ...prev, verified: updated?.verified ?? true } : prev
+      );
+    } catch (error: any) {
+      const message =
+        error?.response?.data?.message ?? "인증에 실패했습니다.";
+      throw new Error(message);
+    }
+  }, []);
+
   const signout = useCallback(async () => {
     await AsyncStorage.removeItem("accessToken");
     await AsyncStorage.removeItem("refreshToken");
@@ -270,6 +294,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       signin,
       kakaoSignin,
       updateName,
+      verifyDouzoneEmail,
       signout,
       processingSignin,
       updateProfileImage,
@@ -283,6 +308,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     signin,
     kakaoSignin,
     updateName,
+    verifyDouzoneEmail,
     signout,
     processingSignin,
     updateProfileImage,

--- a/src/screens/ConnectScreen/ConnectDetailScreen.tsx
+++ b/src/screens/ConnectScreen/ConnectDetailScreen.tsx
@@ -147,14 +147,6 @@ const ConnectDetail = () => {
     }
   }, [me, navigation]);
 
-  const onTextInputContentSizeChange = useCallback((event: any) => {
-    const height = Math.min(
-      150,
-      Math.max(40, event.nativeEvent.contentSize.height)
-    );
-    setReplyInputHeight(height);
-  }, []);
-
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
     if (routes.params.parentId) {
@@ -251,7 +243,6 @@ const ConnectDetail = () => {
   );
 
   const ListHeaderComponent = useCallback(() => {
-    if (!reply) return null;
 
     return (
       <>
@@ -280,15 +271,26 @@ const ConnectDetail = () => {
             <TouchableOpacity
              onPress={() => boardDetail?.userId && boardDetail?.userName && openProfileBottomSheet(boardDetail.userId, boardDetail.userName)}
             >
-              <Text
-                style={{
-                  fontWeight: "bold",
-                  fontSize: 18,
-                  color: "#111827",
-                }}
-              >
-                {boardDetail?.userName}              
-              </Text>
+              <View style={{ flexDirection: "row", alignItems: "center" }}>
+                <Text
+                  style={{
+                    fontWeight: "bold",
+                    fontSize: 18,
+                    color: "#111827",
+                  }}
+                >
+                  {boardDetail?.userName}
+                </Text>
+                {/* 더존 이메일 인증 마크 */}
+                {boardDetail?.verified && (
+                  <MaterialIcons
+                    name="verified"
+                    size={18}
+                    color="#3B82F6"
+                    style={{ marginLeft: 4 }}
+                  />
+                )}
+              </View>
             </TouchableOpacity>
             <Text
               style={{

--- a/src/screens/MyPageScreen/MyPageScreen.tsx
+++ b/src/screens/MyPageScreen/MyPageScreen.tsx
@@ -9,6 +9,7 @@ import {
   StyleSheet,
 } from "react-native";
 import Alert from "@blazejkustra/react-native-alert";
+import { MaterialIcons } from "@expo/vector-icons";
 import Constants from "expo-constants";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import AuthContext from "@/components/auth/AuthContext";
@@ -19,13 +20,20 @@ import { formatRelativeTime } from "@/utils/formatRelativeTime";
 const API_BASE_URL = Constants.expoConfig?.extra?.API_BASE_URL ?? "";
 
 export default function MyPageScreen() {
-  const { user, updateName } = useContext(AuthContext);
+  const { user, updateName, verifyDouzoneEmail } = useContext(AuthContext);
   const navigation = useRootNavigation<"ConnectDetail">();
 
   const [name, setName] = useState(user?.name ?? "");
   const [saving, setSaving] = useState(false);
   const [myPosts, setMyPosts] = useState<Post[]>([]);
   const [loadingPosts, setLoadingPosts] = useState(false);
+
+  // 더존 이메일 인증 상태
+  const [douzoneEmail, setDouzoneEmail] = useState("");
+  const [code, setCode] = useState("");
+  const [codeSent, setCodeSent] = useState(false);
+  const [sendingCode, setSendingCode] = useState(false);
+  const [verifying, setVerifying] = useState(false);
 
   // user 정보가 갱신되면 입력값도 동기화
   useEffect(() => {
@@ -91,6 +99,67 @@ export default function MyPageScreen() {
     }
   }, [name, nameChanged, saving, updateName]);
 
+  // 더존 이메일로 인증번호 발송
+  const onSendCode = useCallback(async () => {
+    const email = douzoneEmail.trim();
+    if (!email.toLowerCase().endsWith("@douzone.com")) {
+      Alert.alert("알림", "@douzone.com 이메일만 인증할 수 있습니다.");
+      return;
+    }
+    setSendingCode(true);
+    try {
+      const token = await AsyncStorage.getItem("accessToken");
+      const res = await fetch(
+        `${API_BASE_URL}/api/account/verify-douzone/send-code`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({ email }),
+        }
+      );
+      const data = await res.json().catch(() => null);
+      if (res.ok) {
+        setCodeSent(true);
+        Alert.alert(
+          "발송 완료",
+          "인증번호를 이메일로 보냈습니다. 메일함을 확인해주세요."
+        );
+      } else {
+        Alert.alert("발송 실패", data?.message ?? "인증번호 발송에 실패했습니다.");
+      }
+    } catch (e) {
+      Alert.alert("발송 실패", "인증번호 발송 중 오류가 발생했습니다.");
+    } finally {
+      setSendingCode(false);
+    }
+  }, [douzoneEmail]);
+
+  // 인증번호 확인 → 인증 완료
+  const onVerify = useCallback(async () => {
+    if (!code.trim()) {
+      Alert.alert("알림", "인증번호를 입력해주세요.");
+      return;
+    }
+    setVerifying(true);
+    try {
+      await verifyDouzoneEmail(douzoneEmail.trim(), code.trim());
+      Alert.alert(
+        "인증 완료",
+        "더존 이메일 인증이 완료되었습니다. 모집 글 이름 옆에 인증 마크가 표시됩니다."
+      );
+      setCode("");
+      setCodeSent(false);
+      setDouzoneEmail("");
+    } catch (e: any) {
+      Alert.alert("인증 실패", e?.message ?? "인증에 실패했습니다.");
+    } finally {
+      setVerifying(false);
+    }
+  }, [code, douzoneEmail, verifyDouzoneEmail]);
+
   return (
     <View style={styles.container}>
       {/* 이름 수정 영역 */}
@@ -123,6 +192,69 @@ export default function MyPageScreen() {
         <Text style={styles.hint}>
           모집 글에 표시되는 이름입니다. 변경하면 새로 쓰는 글부터 반영됩니다.
         </Text>
+      </View>
+
+      <View style={styles.divider} />
+
+      {/* 더존 이메일 인증 */}
+      <View style={styles.section}>
+        <Text style={styles.label}>더존 이메일 인증</Text>
+        {user?.verified ? (
+          <View style={styles.verifiedBadge}>
+            <MaterialIcons name="verified" size={20} color="#3B82F6" />
+            <Text style={styles.verifiedText}>인증 완료</Text>
+          </View>
+        ) : (
+          <>
+            <View style={styles.nameRow}>
+              <TextInput
+                style={styles.input}
+                value={douzoneEmail}
+                onChangeText={setDouzoneEmail}
+                placeholder="name@douzone.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+              />
+              <TouchableOpacity
+                style={[styles.saveBtn, sendingCode && styles.saveBtnDisabled]}
+                onPress={onSendCode}
+                disabled={sendingCode}
+              >
+                {sendingCode ? (
+                  <ActivityIndicator color="#fff" />
+                ) : (
+                  <Text style={styles.saveBtnText}>발송</Text>
+                )}
+              </TouchableOpacity>
+            </View>
+            {codeSent && (
+              <View style={[styles.nameRow, { marginTop: 8 }]}>
+                <TextInput
+                  style={styles.input}
+                  value={code}
+                  onChangeText={setCode}
+                  placeholder="인증번호 6자리"
+                  keyboardType="number-pad"
+                  maxLength={6}
+                />
+                <TouchableOpacity
+                  style={[styles.saveBtn, verifying && styles.saveBtnDisabled]}
+                  onPress={onVerify}
+                  disabled={verifying}
+                >
+                  {verifying ? (
+                    <ActivityIndicator color="#fff" />
+                  ) : (
+                    <Text style={styles.saveBtnText}>인증</Text>
+                  )}
+                </TouchableOpacity>
+              </View>
+            )}
+            <Text style={styles.hint}>
+              @douzone.com 이메일을 인증하면 모집 글 이름 옆에 인증 마크가 표시됩니다.
+            </Text>
+          </>
+        )}
       </View>
 
       <View style={styles.divider} />
@@ -212,6 +344,16 @@ const styles = StyleSheet.create({
     marginTop: 8,
     fontSize: 12,
     color: "#888",
+  },
+  verifiedBadge: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  verifiedText: {
+    marginLeft: 6,
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#3B82F6",
   },
   divider: {
     height: 8,

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface Post {
   destination: string; // 목적지
   maxCapacity: number; // 최대 모집 인원
   currentParticipants: number; // 모집 인원
+  verified?: boolean; // 작성자 더존 이메일 인증 여부
   replies?: Reply[]; // 댓글
 }
 
@@ -54,6 +55,7 @@ export interface User {
   email: string;
   name: string;
   profileUrl?: string;
+  verified?: boolean; // 더존 이메일 인증 여부
 }
 
 export interface CreateCommentRequest {
@@ -82,4 +84,5 @@ export interface ConnectDetailBoardDto {
   userId: string;
   userName: string;
   insertDts: string;
+  verified?: boolean; // 작성자 더존 이메일 인증 여부
 }


### PR DESCRIPTION
## 작업 내용
더존 이메일 인증 + 모집 글 작성자 인증 마크 (프론트). (#50/마이페이지 작업에서 분리)

### 추가/변경
- 마이페이지 더존 이메일(@douzone.com) 인증 UI (인증번호 발송 → 확인) + "인증 완료" 배지
- 모집 글 상세 작성자명 옆 인증 마크(파란 체크)
- `AuthContext.verifyDouzoneEmail` 추가, User/Post/ConnectDetailBoardDto 에 `verified` 반영

### 참고
- base 를 `feature/kakao-login` 으로 설정(스택). 해당 PR 머지 후 base 를 dev 로 변경하면 됩니다.
- 관련 백엔드 이슈: kingle1024/connect-service#127
- 관련 백엔드 PR: kingle1024/connect-service#128