### PR TITLE
✨ Feat: 카카오 로그인 후속 + 드로어/마이페이지 (잔여 커밋)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,12 @@ import { StatusBar } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import Toast from "react-native-toast-message";
+import * as WebBrowser from "expo-web-browser";
+
+// 웹에서 카카오 로그인 팝업이 리다이렉트로 돌아왔을 때 팝업을 자동으로 닫고
+// 결과(토큰이 담긴 URL)를 openAuthSessionAsync 호출부로 전달한다.
+// 모듈 로드 시점에 호출해야 팝업 컨텍스트에서 즉시 세션이 완료된다.
+WebBrowser.maybeCompleteAuthSession();
 
 export default function App() {
   return (

--- a/src/components/auth/AuthContext.tsx
+++ b/src/components/auth/AuthContext.tsx
@@ -8,6 +8,7 @@ export interface AuthContextProp {
   processingSignup: boolean;
   signin: (email: string, password: string) => Promise<void>;
   kakaoSignin: () => Promise<void>;
+  updateName: (name: string) => Promise<void>;
   signout: () => Promise<void>;
   processingSignin: boolean;
   updateProfileImage: (filepath: string) => Promise<void>;
@@ -21,6 +22,7 @@ const AuthContext = createContext<AuthContextProp>({
   processingSignup: false,
   signin: async () => {},
   kakaoSignin: async () => {},
+  updateName: async () => {},
   signout: async () => {},
   processingSignin: false,
   updateProfileImage: async () => {},

--- a/src/components/auth/AuthProvider.tsx
+++ b/src/components/auth/AuthProvider.tsx
@@ -226,6 +226,26 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }
   }, [navigation]);
 
+  // 본인 이름(별칭) 변경. 서버 반영 후 로컬 user 상태도 갱신해 새 글 작성 시 새 이름이 쓰이게 한다.
+  const updateName = useCallback(async (name: string) => {
+    const accessToken = await AsyncStorage.getItem("accessToken");
+    try {
+      const response = await axiosInstance.put(
+        "/api/account/me/name",
+        { name },
+        { headers: { Authorization: `Bearer ${accessToken}` } }
+      );
+      const updated = response.data?.data;
+      if (updated?.name) {
+        setUser((prev) => (prev ? { ...prev, name: updated.name } : prev));
+      }
+    } catch (error: any) {
+      const message =
+        error?.response?.data?.message ?? "이름 변경에 실패했습니다.";
+      throw new Error(message);
+    }
+  }, []);
+
   const signout = useCallback(async () => {
     await AsyncStorage.removeItem("accessToken");
     await AsyncStorage.removeItem("refreshToken");
@@ -249,6 +269,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
       processingSignup,
       signin,
       kakaoSignin,
+      updateName,
       signout,
       processingSignin,
       updateProfileImage,
@@ -261,6 +282,7 @@ const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     processingSignup,
     signin,
     kakaoSignin,
+    updateName,
     signout,
     processingSignin,
     updateProfileImage,

--- a/src/components/drawer/DrawerContent.tsx
+++ b/src/components/drawer/DrawerContent.tsx
@@ -48,7 +48,9 @@ const DrawerContent = (props: DrawerContentComponentProps) => {
         <DrawerItem
           label="설정"
           onPress={() => {
-            // 설정 화면으로 이동
+            // 드로어를 닫고 설정 화면으로 이동
+            props.navigation.closeDrawer();
+            navigation.navigate("Settings");
           }}
           icon={({ color, size }) => (
             <Feather name="settings" color="tomato" size={size} />
@@ -59,7 +61,9 @@ const DrawerContent = (props: DrawerContentComponentProps) => {
         <DrawerItem
           label="도움말"
           onPress={() => {
-            // 도움말 화면으로 이동
+            // 드로어를 닫고 도움말 화면으로 이동
+            props.navigation.closeDrawer();
+            navigation.navigate("Help");
           }}
           icon={({ color, size }) => (
             <Feather name="help-circle" color="tomato" size={size} />
@@ -70,7 +74,9 @@ const DrawerContent = (props: DrawerContentComponentProps) => {
         <DrawerItem
           label="마이페이지"
           onPress={() => {
-            // 마이페이지 화면으로 이동
+            // 드로어를 닫고 마이페이지 화면으로 이동
+            props.navigation.closeDrawer();
+            navigation.navigate("MyPage");
           }}
           icon={({ color, size }) => (
             <MaterialCommunityIcons name="account" color="tomato" size={size} />

--- a/src/navigation/BottomTabNavigation.tsx
+++ b/src/navigation/BottomTabNavigation.tsx
@@ -16,6 +16,7 @@ const BottomTabNavigation = () => {
 
   return (
     <BottomTab.Navigator
+      initialRouteName="Connect"
       screenOptions={{
         tabBarActiveTintColor: "tomato",
         tabBarInactiveTintColor: "gray",

--- a/src/navigation/RootNavigation.tsx
+++ b/src/navigation/RootNavigation.tsx
@@ -9,6 +9,8 @@ import SigninScreen from "@/screens/SigninScreen/SigninScreen";
 import MyPageScreen from "@/screens/MyPageScreen/MyPageScreen";
 import SignupScreen from "@/screens/SignUpScreen/SignupScreen";
 import FindPasswordScreen from "@/screens/FindAccountScreen/FindPasswordScreen";
+import SettingsScreen from "@/screens/SettingsScreen/SettingsScreen";
+import HelpScreen from "@/screens/HelpScreen/HelpScreen";
 
 const Stack = createNativeStackNavigator();
 
@@ -69,7 +71,21 @@ export const RootNavigation = () => {
         })}
       />
       <Stack.Screen name="FindPassword" component={FindPasswordScreen} />
-      <Stack.Screen name="MyPage" component={MyPageScreen} />
+      <Stack.Screen
+        name="MyPage"
+        component={MyPageScreen}
+        options={{ headerShown: true, title: "마이페이지" }}
+      />
+      <Stack.Screen
+        name="Settings"
+        component={SettingsScreen}
+        options={{ headerShown: true, title: "설정" }}
+      />
+      <Stack.Screen
+        name="Help"
+        component={HelpScreen}
+        options={{ headerShown: true, title: "도움말" }}
+      />
       <Stack.Screen name="채팅방 상세" component={EnterChatRoom} />
     </Stack.Navigator>
   );

--- a/src/screens/FriendScreen/FriendsListScreen.tsx
+++ b/src/screens/FriendScreen/FriendsListScreen.tsx
@@ -11,8 +11,8 @@ import {
   ActivityIndicator,
 } from "react-native";
 import Alert from '@blazejkustra/react-native-alert';
-import { useNavigation, NavigationProp } from "@react-navigation/native";
-import { Feather, AntDesign } from "@expo/vector-icons";
+import { useNavigation, NavigationProp, DrawerActions } from "@react-navigation/native";
+import { Feather } from "@expo/vector-icons";
 import FriendItem from "@/components/FriendItem";
 import Constants from "expo-constants";
 import AsyncStorage from "@react-native-async-storage/async-storage";
@@ -431,12 +431,14 @@ const FriendsListScreen = () => {
       <View style={styles.header}>
         <Text style={styles.headerTitle}>친구</Text>
         <View style={styles.headerRight}>
-          {/* <TouchableOpacity style={styles.iconBtn}>
-            <Feather name="user-plus" size={20} color="#333" />
+          {/* 우측 상단 햄버거: 설정·마이페이지 등 드로어 토글 (모집 화면과 동일) */}
+          <TouchableOpacity
+            onPress={() => navigation.dispatch(DrawerActions.toggleDrawer())}
+            style={{ padding: 5 }}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
+            <Feather name="menu" size={24} color="#333" />
           </TouchableOpacity>
-          <TouchableOpacity style={styles.iconBtn}>
-            <AntDesign name="setting" size={20} color="#333" />
-          </TouchableOpacity> */}
         </View>
       </View>
 

--- a/src/screens/HelpScreen/HelpScreen.tsx
+++ b/src/screens/HelpScreen/HelpScreen.tsx
@@ -1,0 +1,32 @@
+import { StyleSheet, Text, View } from "react-native";
+
+// 도움말 화면 (드로어 > 도움말 진입)
+const HelpScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>도움말</Text>
+      <Text style={styles.desc}>준비 중인 화면입니다.</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#f0f2f5",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    color: "#333",
+  },
+  desc: {
+    fontSize: 16,
+    color: "#666",
+    marginTop: 10,
+  },
+});
+
+export default HelpScreen;

--- a/src/screens/MyPageScreen/MyPageScreen.tsx
+++ b/src/screens/MyPageScreen/MyPageScreen.tsx
@@ -1,27 +1,248 @@
-// src/screens/MyPageScreen.js
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  FlatList,
+  ActivityIndicator,
+  StyleSheet,
+} from "react-native";
+import Alert from "@blazejkustra/react-native-alert";
+import Constants from "expo-constants";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import AuthContext from "@/components/auth/AuthContext";
+import { Post } from "@/types";
+import { useRootNavigation } from "@/hooks/useNavigation";
+import { formatRelativeTime } from "@/utils/formatRelativeTime";
 
-import { StyleSheet, Text, View } from 'react-native';
-
-const styles = StyleSheet.create({
-  screenContainer: {
-    flex: 1,
-    backgroundColor: '#f0f2f5',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  header: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    color: '#333',
-  },
-});
+const API_BASE_URL = Constants.expoConfig?.extra?.API_BASE_URL ?? "";
 
 export default function MyPageScreen() {
+  const { user, updateName } = useContext(AuthContext);
+  const navigation = useRootNavigation<"ConnectDetail">();
+
+  const [name, setName] = useState(user?.name ?? "");
+  const [saving, setSaving] = useState(false);
+  const [myPosts, setMyPosts] = useState<Post[]>([]);
+  const [loadingPosts, setLoadingPosts] = useState(false);
+
+  // user 정보가 갱신되면 입력값도 동기화
+  useEffect(() => {
+    setName(user?.name ?? "");
+  }, [user?.name]);
+
+  // 내가 올린 글 조회
+  const fetchMyPosts = useCallback(async () => {
+    if (!user?.userId) {
+      setMyPosts([]);
+      return;
+    }
+    setLoadingPosts(true);
+    try {
+      const token = await AsyncStorage.getItem("accessToken");
+      const res = await fetch(
+        `${API_BASE_URL}/api/boards/author/${encodeURIComponent(user.userId)}`,
+        {
+          headers: {
+            Accept: "application/json",
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          },
+        }
+      );
+      if (res.ok) {
+        const data = await res.json();
+        setMyPosts(Array.isArray(data?.posts) ? data.posts : []);
+      } else {
+        console.warn("fetchMyPosts failed:", res.status);
+      }
+    } catch (e) {
+      console.warn("fetchMyPosts error:", e);
+    } finally {
+      setLoadingPosts(false);
+    }
+  }, [user?.userId]);
+
+  useEffect(() => {
+    fetchMyPosts();
+  }, [fetchMyPosts]);
+
+  // 이름이 실제로 바뀌었고 비어있지 않을 때만 저장 가능
+  const nameChanged = useMemo(() => {
+    const trimmed = name.trim();
+    return trimmed.length > 0 && trimmed !== (user?.name ?? "");
+  }, [name, user?.name]);
+
+  const onPressSave = useCallback(async () => {
+    if (!nameChanged || saving) {
+      return;
+    }
+    setSaving(true);
+    try {
+      await updateName(name.trim());
+      Alert.alert(
+        "저장 완료",
+        "이름이 변경되었습니다. 새로 작성하는 모집 글부터 반영됩니다."
+      );
+    } catch (e: any) {
+      Alert.alert("저장 실패", e?.message ?? "이름 변경 중 오류가 발생했습니다.");
+    } finally {
+      setSaving(false);
+    }
+  }, [name, nameChanged, saving, updateName]);
+
   return (
-    <View style={styles.screenContainer}>
-      <Text style={styles.header}>마이페이지</Text>
-      <Text style={{ fontSize: 16, color: '#666', marginTop: 10 }}></Text>
-      {/* 여기에 사용자 프로필, 설정, 내 게시물 목록 등을 구현 */}
+    <View style={styles.container}>
+      {/* 이름 수정 영역 */}
+      <View style={styles.section}>
+        <Text style={styles.label}>이름</Text>
+        <View style={styles.nameRow}>
+          <TextInput
+            style={styles.input}
+            value={name}
+            onChangeText={setName}
+            placeholder="이름을 입력하세요"
+            maxLength={20}
+            autoCapitalize="none"
+          />
+          <TouchableOpacity
+            style={[
+              styles.saveBtn,
+              (!nameChanged || saving) && styles.saveBtnDisabled,
+            ]}
+            onPress={onPressSave}
+            disabled={!nameChanged || saving}
+          >
+            {saving ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.saveBtnText}>저장</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+        <Text style={styles.hint}>
+          모집 글에 표시되는 이름입니다. 변경하면 새로 쓰는 글부터 반영됩니다.
+        </Text>
+      </View>
+
+      <View style={styles.divider} />
+
+      {/* 내가 올린 글 */}
+      <Text style={[styles.label, styles.postsHeader]}>내가 올린 글</Text>
+      {loadingPosts ? (
+        <ActivityIndicator style={{ marginTop: 20 }} />
+      ) : (
+        <FlatList
+          data={myPosts}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              style={styles.postItem}
+              onPress={() =>
+                navigation.navigate("ConnectDetail", { parentId: item.id })
+              }
+            >
+              <Text style={styles.postTitle} numberOfLines={1}>
+                {item.title}
+              </Text>
+              <Text style={styles.postMeta} numberOfLines={1}>
+                {item.destination} · {formatRelativeTime(item.insertDts)} · 댓글{" "}
+                {item.commentCount}
+              </Text>
+            </TouchableOpacity>
+          )}
+          ListEmptyComponent={() => (
+            <View style={styles.empty}>
+              <Text style={styles.emptyText}>작성한 글이 없습니다.</Text>
+            </View>
+          )}
+          contentContainerStyle={{ paddingBottom: 32 }}
+        />
+      )}
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+  section: {
+    padding: 16,
+  },
+  label: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: "#333",
+    marginBottom: 8,
+  },
+  nameRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: "#ddd",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 16,
+    marginRight: 8,
+  },
+  saveBtn: {
+    backgroundColor: "tomato",
+    borderRadius: 8,
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    minWidth: 64,
+  },
+  saveBtnDisabled: {
+    backgroundColor: "#ccc",
+  },
+  saveBtnText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "bold",
+  },
+  hint: {
+    marginTop: 8,
+    fontSize: 12,
+    color: "#888",
+  },
+  divider: {
+    height: 8,
+    backgroundColor: "#f0f2f5",
+  },
+  postsHeader: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+  },
+  postItem: {
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: "#eee",
+  },
+  postTitle: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#222",
+  },
+  postMeta: {
+    marginTop: 4,
+    fontSize: 12,
+    color: "#888",
+  },
+  empty: {
+    alignItems: "center",
+    paddingVertical: 40,
+  },
+  emptyText: {
+    fontSize: 14,
+    color: "#999",
+  },
+});

--- a/src/screens/SettingsScreen/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen/SettingsScreen.tsx
@@ -1,0 +1,32 @@
+import { StyleSheet, Text, View } from "react-native";
+
+// 설정 화면 (드로어 > 설정 진입)
+const SettingsScreen = () => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>설정</Text>
+      <Text style={styles.desc}>준비 중인 화면입니다.</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#f0f2f5",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "bold",
+    color: "#333",
+  },
+  desc: {
+    fontSize: 16,
+    color: "#666",
+    marginTop: 10,
+  },
+});
+
+export default SettingsScreen;

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,9 @@ export type TypeRootStackNavigationParams = {
   Signup: undefined;
   Signin: undefined;
   FindPassword: undefined;
+  MyPage: undefined;
+  Settings: undefined;
+  Help: undefined;
 };
 
 export type TypeBottomTabNavigationParams = {


### PR DESCRIPTION
#50 카카오 로그인 후속(팝업 종료/첫 화면 모집) + 드로어(설정/도움말/마이페이지) + 친구탭 햄버거 + 마이페이지(이름 수정·내 글) 잔여 커밋을 dev 에 머지합니다. (이전 PR #138 은 첫 커밋만 머지됨)

관련 백엔드 이슈: kingle1024/connect-service#50