### PR TITLE
🐛 Fix: 로그인 등 화면 브라우저 title undefined 수정

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,7 +18,13 @@ export default function App() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>
         <ActionSheetProvider>
-          <NavigationContainer>
+          <NavigationContainer
+            // 웹 브라우저 탭 title. 화면의 title 옵션 → 라우트명 → 앱명 순으로 fallback (undefined 방지)
+            documentTitle={{
+              formatter: (options, route) =>
+                (options?.title as string) ?? route?.name ?? "같이타",
+            }}
+          >
             <StatusBar
               translucent
               backgroundColor="transparent"

--- a/src/navigation/RootNavigation.tsx
+++ b/src/navigation/RootNavigation.tsx
@@ -55,6 +55,7 @@ export const RootNavigation = () => {
       <Stack.Screen
         name="Signin"
         component={SigninScreen}
+        options={{ title: "로그인" }}
         listeners={({ navigation }) => ({
           focus: () => {
             navigation.getParent()?.setOptions({ swipeEnabled: false });
@@ -64,13 +65,18 @@ export const RootNavigation = () => {
       <Stack.Screen
         name="Signup"
         component={SignupScreen}
+        options={{ title: "회원가입" }}
         listeners={({ navigation }) => ({
           focus: () => {
             navigation.getParent()?.setOptions({ swipeEnabled: false });
           },
         })}
       />
-      <Stack.Screen name="FindPassword" component={FindPasswordScreen} />
+      <Stack.Screen
+        name="FindPassword"
+        component={FindPasswordScreen}
+        options={{ title: "비밀번호 찾기" }}
+      />
       <Stack.Screen
         name="MyPage"
         component={MyPageScreen}


### PR DESCRIPTION
로그인/회원가입/비밀번호찾기 화면에 title 옵션이 없어 웹 탭 title이 undefined로 표시되던 문제 수정. 각 화면 title 명시 + NavigationContainer documentTitle fallback formatter 추가.