### PR TITLE
🐛 Fix: 앱 이름(초기 탭 제목)을 같이타로 변경

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -4,7 +4,7 @@ module.exports = ({ config }) => {
   // 기본 설정
   const defaultConfig = {
     ...config, // 기존 app.json의 내용들을 여기에 합쳐도 됨
-    name: "MyExpoApp",
+    name: "같이타",
     slug: "myexpoapp",
     version: "1.0.0",
     scheme: "connect", // 카카오 로그인 등 OAuth 딥링크(connect://...)용 스킴


### PR DESCRIPTION
app.config.js name 을 MyExpoApp → 같이타 로 변경. 웹 새로고침 시 라우트 title 적용 전 보이던 MyExpoApp 표시 개선.