### PR TITLE
🐛 Fix: 미로그인 시 마이페이지 → 로그인 페이지로 유도

### DIFF
--- a/src/components/drawer/DrawerContent.tsx
+++ b/src/components/drawer/DrawerContent.tsx
@@ -74,9 +74,13 @@ const DrawerContent = (props: DrawerContentComponentProps) => {
         <DrawerItem
           label="마이페이지"
           onPress={() => {
-            // 드로어를 닫고 마이페이지 화면으로 이동
+            // 드로어를 닫고 마이페이지로 이동. 미로그인 시 로그인 페이지로 유도
             props.navigation.closeDrawer();
-            navigation.navigate("MyPage");
+            if (me) {
+              navigation.navigate("MyPage");
+            } else {
+              navigation.navigate("Signin");
+            }
           }}
           icon={({ color, size }) => (
             <MaterialCommunityIcons name="account" color="tomato" size={size} />

--- a/src/screens/MyPageScreen/MyPageScreen.tsx
+++ b/src/screens/MyPageScreen/MyPageScreen.tsx
@@ -31,8 +31,15 @@ type Reminder = {
 };
 
 export default function MyPageScreen() {
-  const { user, updateName, verifyDouzoneEmail } = useContext(AuthContext);
+  const { user, initialized, updateName, verifyDouzoneEmail } = useContext(AuthContext);
   const navigation = useRootNavigation<"ConnectDetail">();
+
+  // 미로그인 상태로 진입하면 로그인 페이지로 이동 (초기화 완료 후 판단해 새로고침 깜빡임 방지)
+  useEffect(() => {
+    if (initialized && !user) {
+      navigation.navigate("Signin");
+    }
+  }, [initialized, user, navigation]);
 
   const [name, setName] = useState(user?.name ?? "");
   const [saving, setSaving] = useState(false);


### PR DESCRIPTION
미로그인 상태에서 드로어 마이페이지가 그냥 열리던 문제 수정. 드로어 클릭 시 미로그인이면 Signin 으로 이동 + MyPageScreen 진입 가드(초기화 완료 후 미로그인이면 Signin).